### PR TITLE
added support for Mailgun regions

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,3 +6,6 @@ Revision history for Perl extension Email-Sender-Transport-Mailgun
 
     - original version
 
+0.02 2019-11-26T14:03:00Z
+
+    - support for Mailgun regions (fhelmberger)

--- a/META.json
+++ b/META.json
@@ -73,6 +73,6 @@
          "web" : "https://github.com/sdt/Email-Sender-Transport-Mailgun"
       }
    },
-   "version" : "0.01",
+   "version" : "0.02",
    "x_serialization_backend" : "JSON::PP version 2.27300"
 }

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Mailgun domain. See [https://documentation.mailgun.com/api-intro.html#base-url](
 
 # OPTIONAL ATTRIBUTES
 
-These correspond to the `o:` options in the `messages.mime` section of
-[https://documentation.mailgun.com/api-sending.html#sending](https://documentation.mailgun.com/api-sending.html#sending)
+These (except region) correspond to the `o:` options in the `messages.mime`
+section of [https://documentation.mailgun.com/api-sending.html#sending](https://documentation.mailgun.com/api-sending.html#sending)
 
 ## campaign
 
@@ -65,6 +65,12 @@ Desired time of delivery. String or DateTime object.
 ## dkim
 
 Enables/disables DKIM signatures. `'yes'` or `'no'`.
+
+## region
+
+Defines used Mailgun region. `'us'` (default) or `'eu'`.
+
+See [https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions](https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions).
 
 ## tag
 
@@ -113,6 +119,7 @@ To specify any of the attributes above, prepend the attribute name with
 - EMAIL\_SENDER\_TRANSPORT\_campaign
 - EMAIL\_SENDER\_TRANSPORT\_deliverytime
 - EMAIL\_SENDER\_TRANSPORT\_dkim
+- EMAIL\_SENDER\_TRANSPORT\_region
 - EMAIL\_SENDER\_TRANSPORT\_tag
 - EMAIL\_SENDER\_TRANSPORT\_testmode
 - EMAIL\_SENDER\_TRANSPORT\_tracking

--- a/lib/Email/Sender/Transport/Mailgun.pm
+++ b/lib/Email/Sender/Transport/Mailgun.pm
@@ -56,6 +56,12 @@ has tracking_clicks => (
     isa => Enum[qw( yes no htmlonly )],
 );
 
+has region => (
+    is => 'ro',
+    predicate => 1,
+    isa => Enum[qw/us eu/],
+);
+
 has base_uri => (
     is => 'lazy',
     builder => sub { 'https://api.mailgun.net/v3' },
@@ -139,6 +145,10 @@ sub _build_uri {
     my $api_key = $self->api_key;
     my $domain = $self->domain;
 
+    # adapt endpoint based on region setting.
+    $rest =~ s/(\.mailgun)/sprintf('.%s%s', $self->region, $1)/e
+        if defined $self->region && $self->region ne 'us';
+
     return "$proto://api:$api_key\@$rest/$domain";
 }
 
@@ -202,8 +212,8 @@ Mailgun domain. See L<https://documentation.mailgun.com/api-intro.html#base-url>
 
 =head1 OPTIONAL ATTRIBUTES
 
-These correspond to the C<o:> options in the C<messages.mime> section of
-L<https://documentation.mailgun.com/api-sending.html#sending>
+These (except region) correspond to the C<o:> options in the C<messages.mime>
+section of L<https://documentation.mailgun.com/api-sending.html#sending>
 
 =head2 campaign
 
@@ -216,6 +226,12 @@ Desired time of delivery. String or DateTime object.
 =head2 dkim
 
 Enables/disables DKIM signatures. C<'yes'> or C<'no'>.
+
+-head2 region
+
+Defines used Mailgun region. C<'us'> (default) or C<'eu'>.
+
+See L<https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions>.
 
 =head2 tag
 
@@ -270,6 +286,8 @@ C<EMAIL_SENDER_TRANSPORT_>.
 =item EMAIL_SENDER_TRANSPORT_deliverytime
 
 =item EMAIL_SENDER_TRANSPORT_dkim
+
+=item EMAIL_SENDER_TRANSPORT_region
 
 =item EMAIL_SENDER_TRANSPORT_tag
 

--- a/t/region.t
+++ b/t/region.t
@@ -1,0 +1,35 @@
+use strict;
+use Test::More;
+use Test::Fatal;
+
+use Email::Sender::Transport::Mailgun;
+
+my $transport;
+
+$transport = Email::Sender::Transport::Mailgun->new(api_key => 'k', domain => 'd');
+is(extract_api($transport->uri), 'api.mailgun.net', 'no region given');
+
+$transport = Email::Sender::Transport::Mailgun->new(api_key => 'k', domain => 'd', region   => 'us');
+is(extract_api($transport->uri), 'api.mailgun.net', 'us region set');
+
+$transport = Email::Sender::Transport::Mailgun->new(api_key => 'k', domain => 'd', region   => 'eu');
+is(extract_api($transport->uri), 'api.eu.mailgun.net', 'eu region');
+
+my $ex = exception {
+    Email::Sender::Transport::Mailgun->new(api_key => 'k', domain => 'd', region => 'at');
+};
+
+like(
+    $ex,
+    qr/^isa check for "region" failed: at is not any of the possible values:/,
+    'exception when using unknown region'
+);
+
+done_testing;
+
+sub extract_api {
+    my $uri = shift;
+    return unless defined $uri and $uri ne '';
+    $uri =~ m!@(.+?)/!;
+    $1;
+}


### PR DESCRIPTION
https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions

Allows to select Mailgun region via new region attribute (EMAIL_SENDER_TRANSPORT_region environment variable). Allowed values: us (default), eu.

If set, adapts the base_uri corresponding to the selected region.

If Mailgun adds another region it simply has to be added to the Enum constraint of the region attribute.

Added new test t/region.t.