### PR TITLE
Remove campaign attribute

### DIFF
--- a/lib/Email/Sender/Transport/Mailgun.pm
+++ b/lib/Email/Sender/Transport/Mailgun.pm
@@ -27,7 +27,7 @@ has [qw( api_key domain )] => (
     isa => Str,
 );
 
-has [qw( campaign tag )] => (
+has [qw( tag )] => (
     is => 'ro',
     predicate => 1,
     isa => ArrayRef[Str],
@@ -94,8 +94,7 @@ sub send_email {
     };
 
     my @options = qw(
-        campaign deliverytime dkim tag testmode
-        tracking tracking_clicks tracking_opens
+        deliverytime dkim tag testmode tracking tracking_clicks tracking_opens
     );
 
     for my $option (@options) {
@@ -219,10 +218,6 @@ Mailgun domain. See L<https://documentation.mailgun.com/en/latest/api-intro.html
 These (except region) correspond to the C<o:> options in the C<messages.mime>
 section of L<https://documentation.mailgun.com/en/latest/api-sending.html#sending>
 
-=head2 campaign
-
-Id of the campaign. Comma-separated string list or arrayref of strings.
-
 =head2 deliverytime
 
 Desired time of delivery. String or DateTime object.
@@ -284,8 +279,6 @@ C<EMAIL_SENDER_TRANSPORT_>.
 =item EMAIL_SENDER_TRANSPORT_api_key
 
 =item EMAIL_SENDER_TRANSPORT_domain
-
-=item EMAIL_SENDER_TRANSPORT_campaign
 
 =item EMAIL_SENDER_TRANSPORT_deliverytime
 

--- a/t/success.t
+++ b/t/success.t
@@ -47,14 +47,12 @@ my $when = DateTime->new(
     time_zone => 'UTC',
 );
 
-my $campaign = [qw( campaign1 campaign2 )];
 my $tag      = [qw( tag1 tag2 tag3 )];
 
 my $transport = Email::Sender::Transport::Mailgun->new(
     api_key  => $api_key,
     domain   => $domain,
     base_uri => "$proto://$host",
-    campaign => $campaign,
     tag      => join(', ', @$tag),
     tracking_clicks => 'htmlonly',
     deliverytime => $when,
@@ -85,7 +83,6 @@ eq_or_diff($req->{form}, {
     },
     to                  => body($envelope{to}),
     'o:tag'             => body(@$tag),
-    'o:campaign'        => body(@$campaign),
     'o:deliverytime'    => body('Fri, 31 Dec 2066 23:59:59 +0000'),
     'o:tracking-clicks' => body('htmlonly'),
 }, 'Message format as expected');


### PR DESCRIPTION
This is no longer supported by Mailgun. Use tags instead.