### PR TITLE
Require HTTP::Tiny 0.037

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Email-Sender-Transport-Mailgun
 
 {{$NEXT}}
 
+    - need HTTP::Tiny >= 0.037 for apikey encoding
+
 0.03 2022-06-19T22:58:43Z
 
     - fix documentation links (#3)

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Email-Sender-Transport-Mailgun
 
 {{$NEXT}}
 
+0.04 2022-06-23T02:01:20Z
+
     - need HTTP::Tiny >= 0.037 for apikey encoding
 
 0.03 2022-06-19T22:58:43Z

--- a/META.json
+++ b/META.json
@@ -43,7 +43,7 @@
       "runtime" : {
          "requires" : {
             "Email::Sender" : "0",
-            "HTTP::Tiny" : "0",
+            "HTTP::Tiny" : "0.037",
             "HTTP::Tiny::Multipart" : "0",
             "IO::Socket::SSL" : "0",
             "JSON::MaybeXS" : "0",
@@ -73,7 +73,7 @@
          "web" : "https://github.com/sdt/Email-Sender-Transport-Mailgun"
       }
    },
-   "version" : "0.03",
+   "version" : "0.04",
    "x_contributors" : [
       "Florian Helmberger <fh@25th-floor.com>",
       "Stephen Thirlwall <sdt@dr.com>"

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'perl', '5.008001';
 
 requires 'Email::Sender';
-requires 'HTTP::Tiny';
+requires 'HTTP::Tiny', '>= 0.037';
 requires 'HTTP::Tiny::Multipart';
 requires 'IO::Socket::SSL';
 requires 'JSON::MaybeXS';

--- a/lib/Email/Sender/Transport/Mailgun.pm
+++ b/lib/Email/Sender/Transport/Mailgun.pm
@@ -1,5 +1,5 @@
 package Email::Sender::Transport::Mailgun;
-our $VERSION = "0.03";
+our $VERSION = "0.04";
 
 use Moo;
 with 'Email::Sender::Transport';


### PR DESCRIPTION
Require HTTP::Tiny 0.037 or higher for proper url-encoded basic auth credential support

Fixes: http://www.cpantesters.org/cpan/report/b5659920-f123-11ec-a62c-7aa32cbfd570