### PR TITLE
Retry API requests on 5xx response

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Email-Sender-Transport-Mailgun
 
 {{$NEXT}}
 
+    - retry API requests on 5xx response
+
 0.04 2022-06-23T02:01:20Z
 
     - need HTTP::Tiny >= 0.037 for apikey encoding

--- a/lib/Email/Sender/Transport/Mailgun.pm
+++ b/lib/Email/Sender/Transport/Mailgun.pm
@@ -62,6 +62,16 @@ has region => (
     isa => Enum[qw( us eu )],
 );
 
+has retry_count => (
+    is => 'lazy',
+    builder => sub { 3 }, # set to 0 to disable retries
+);
+
+has retry_delay_seconds => (
+    is => 'lazy',
+    builder => sub { 1 },
+);
+
 has base_uri => (
     is => 'lazy',
     builder => sub { 'https://api.mailgun.net/v3' },
@@ -107,7 +117,18 @@ sub send_email {
     }
 
     my $uri = $self->uri . '/messages.mime';
-    my $response = $self->ua->post_multipart($uri, $content);
+
+    # If we get a 5xx error, retry a few times.
+    # Been seeing "Socket closed by remote server: Broken pipe" errors (EPIPE).
+    my $retries = 0;
+
+    my $response;
+    while (1) {
+        $response = $self->ua->post_multipart($uri, $content);
+        last if $response->{status} !~ /^5/;
+        last if $retries++ >= $self->retry_count;
+        sleep $self->retry_delay_seconds;
+    }
 
     $self->failure($response, $env->{to})
         unless $response->{success};
@@ -232,6 +253,14 @@ Defines used Mailgun region. C<'us'> (default) or C<'eu'>.
 
 See L<https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions-1>
 
+=head2 retry_count
+
+=head2 retry_delay_seconds
+
+If the Mailgun API request fails with a 5xx response, the request will be retried C<retry_count> times, with a delay of C<retry_delay_seconds> between each attempt.
+
+Defaults to three retries with a one second delay.
+
 =head2 tag
 
 Tag string. Comma-separated string list or arrayref of strings.
@@ -285,6 +314,10 @@ C<EMAIL_SENDER_TRANSPORT_>.
 =item EMAIL_SENDER_TRANSPORT_dkim
 
 =item EMAIL_SENDER_TRANSPORT_region
+
+=item EMAIL_SENDER_TRANSPORT_retry_count
+
+=item EMAIL_SENDER_TRANSPORT_retry_delay_seconds
 
 =item EMAIL_SENDER_TRANSPORT_tag
 

--- a/t/retry.t
+++ b/t/retry.t
@@ -1,0 +1,79 @@
+use strict;
+use Test::More;
+use Test::Fatal;
+use Test::Differences;
+
+use DateTime;
+use Email::Sender::Transport::Mailgun;
+
+{
+    no warnings 'redefine';
+    *HTTP::Tiny::request = \&mock_request;
+}
+
+my $proto   = 'http';
+my $host    = 'mailgun.example.com';
+my $api_key = 'abcdef';
+my $domain  = 'test.example.com';
+my $id      = '<return value>';
+my $error   = 'Send failed';
+
+my %envelope = (
+    from => 'sender@test.example.com',
+    to   => 'recipient@test.example.com',
+);
+
+my $message = <<END_MESSAGE;
+From: $envelope{from}
+To: $envelope{to}
+Subject: this message is going nowhere fast
+
+Dear Recipient,
+
+  You will never receive this.
+
+--
+sender
+END_MESSAGE
+
+my $transport = Email::Sender::Transport::Mailgun->new(
+    api_key             => $api_key,
+    domain              => $domain,
+    base_uri            => "$proto://$host",
+    retry_delay_seconds => 0, # no need to wait around
+);
+
+my $next_mock_request_fails = 0;
+for my $failures_before_success (0 .. $transport->retry_count+2) {
+
+    # Set the mock user agent to fail N times before succeeding.
+    $next_mock_request_fails = $failures_before_success;
+
+
+    my $result;
+    my $ex = exception { $result = $transport->send($message, \%envelope) };
+
+    my $should_succeed = $failures_before_success <= $transport->retry_count;
+    if ($should_succeed) {
+        is_deeply($ex, undef,
+            "Mail sent ok after $failures_before_success failures");
+        isa_ok($result, 'Email::Sender::Success::MailgunSuccess',
+            'Return value type correct');
+        is($result->id, $id, 'Return id correct');
+    }
+    else {
+        my $failure_count = $transport->retry_count + 1;
+        isa_ok($ex, 'Email::Sender::Failure',
+            "Mail failed after $failure_count of $failures_before_success failures");
+        is($ex->message, $error, 'Got error message');
+    }
+}
+
+done_testing;
+
+# Simulate N failing requests before a successful request.
+sub mock_request {
+    return $next_mock_request_fails-- > 0
+        ? { success => 0, content => qq({"message":"$error"}), status => 599 }
+        : { success => 1, content => qq({"id":"$id"}),         status => 200 };
+}


### PR DESCRIPTION
If the API requests fail with a 5xx response, retry `retry_count` times with a `retry_delay_seconds` delay in between.

Been getting sporadic 599 errors from HTTP::Tiny caused by EPIPE failures on the socket.